### PR TITLE
Avoid google-crc32c on armv7 machines

### DIFF
--- a/src/aiortc/rtcsctptransport.py
+++ b/src/aiortc/rtcsctptransport.py
@@ -22,7 +22,11 @@ from typing import (
     no_type_check,
 )
 
-from google_crc32c import value as crc32c
+import platform
+if platform.machine().lower().startswith('armv7'):
+    from binascii import crc32 as crc32c
+else:
+    from google_crc32c import value as crc32c
 from pyee.asyncio import AsyncIOEventEmitter
 
 from .exceptions import InvalidStateError


### PR DESCRIPTION
On armv7l boards (for example, Raspberry Pi 3 and Zero 2W) google-crc32c falls back to a pure Python implementation as there is no build support for this platform. This patch makes rtcsctptransport.py fall back to Python's builtin `binascii.crc32` in this case which has a C implemtation in CPython.

Runtime warning of google-crc32 on armv7l:

    google_crc32c/__init__.py:29: RuntimeWarning:
        As the c extension couldn't be imported,
        `google-crc32c` is using a pure python
        implementation that is significantly slower.
        If possible, please configure a c build
        environment and compile the extension.

